### PR TITLE
Removes duplicated statement from get_colors_for_numareas

### DIFF
--- a/R/BioGeoBEARS_plots_v1.R
+++ b/R/BioGeoBEARS_plots_v1.R
@@ -419,10 +419,6 @@ get_colors_for_numareas = function(numareas, use_rainbow=FALSE)
 		{
 		area_colors = c("blue", "cyan", "green3", "yellow", "orange", "red", "violet")
 		}
-	if (numareas == 7)
-		{
-		area_colors = c("blue", "cyan", "green3", "yellow", "orange", "red", "violet")
-		}
 	if (numareas > 7)
 		{
 		area_colors = col2rgb(rainbow(numareas))


### PR DESCRIPTION
In `get_colors_for_numareas` the statement that defines the `area_colors` when `num_areas == 7` was duplicated
