### PR TITLE
fix(optimx): Fix version checking for optimx

### DIFF
--- a/R/BioGeoBEARS_SSEsim_makePlots_v1.R
+++ b/R/BioGeoBEARS_SSEsim_makePlots_v1.R
@@ -145,7 +145,7 @@ plot_simDEC_DECJ_inferences <- function(simdir=NULL, sim_params_Rdata_table="/si
 	if (BioGeoBEARS_run_object$use_optimx == TRUE)
 		{
 		# Using optimx() results
-		if (packageVersion("optimx") < 2013)
+		if (packageVersion("optimx") < "2013")
 			{
 			# optimx 2012
 			LnL_2 = as.numeric(resDEC$optim_result$fvalues)

--- a/R/BioGeoBEARS_classes_v1.R
+++ b/R/BioGeoBEARS_classes_v1.R
@@ -1215,7 +1215,7 @@ get_params_from_optim_or_optimx_result <- function(optimx_result, use_optimx=TRU
 		# optimx 2013 has different output; params are in p1, p2, etc.
 		
 		# Check for optimx 2012 or 2013, and extract parameters accordingly
-		if (packageVersion("optimx") < 2013)
+		if (packageVersion("optimx") < "2013")
 			{
 			# optimx 2012
 			params_from_ML = get_params_from_optimx2012(optimx_result)
@@ -1338,7 +1338,7 @@ put_params_into_optim_or_optimx_result <- function(BioGeoBEARS_model_object, tot
 		# optimx 2013 has different output; params are in p1, p2, etc.
 		
 		# Check for optimx 2012 or 2013, and extract parameters accordingly
-		if (packageVersion("optimx") < 2013)
+		if (packageVersion("optimx") < "2013")
 			{
 			###########################
 			# optimx 2012
@@ -1493,7 +1493,7 @@ get_LnL_from_optim_result <- function(optimx_result, use_optimx=TRUE)
 	if ( (use_optimx == TRUE) || (use_optimx == "optimx") )
 		{
 		# Using optimx() results
-		if (packageVersion("optimx") < 2013)
+		if (packageVersion("optimx") < "2013")
 			{
 			# optimx 2012
 			LnL = get_LnL_from_optimx2012(optimx_result)

--- a/R/BioGeoBEARS_univ_model_v1.R
+++ b/R/BioGeoBEARS_univ_model_v1.R
@@ -566,19 +566,18 @@ bears_optim_run <- function(BioGeoBEARS_run_object = define_BioGeoBEARS_run(), s
 	# some R systems
 	# 
 	# Error in assign ("last.warning", NULL, envir = baseenv ()):
-  # it is not possible to add 'last.warning' binding to the base environment
-  #
-  # This page:
-  # https://stackoverflow.com/questions/5725106/r-how-to-clear-all-warnings
-  # 
-  # ...suggests:
-  # 
-  # The error message is Error in assign("last.warning"...) occurres on non-vanilla R platforms 
-  # (i.e. MRO and RRO), because last.warning is locked by default. To unlock the binding, use 
-  # unlockBinding("last.warning", baseenv()). This implementation is consistent with ?warning, w
-  # which says "If warn is zero (the default), a read-only variable last.warning is created."
-  #  – Jthorpe Mar 9 '16 at 21:39
-  # 
+	# it is not possible to add 'last.warning' binding to the base environment
+	#
+	# This page:
+	# https://stackoverflow.com/questions/5725106/r-how-to-clear-all-warnings
+	# 
+	# ...suggests:
+	# 
+	# The error message is Error in assign("last.warning"...) occurres on non-vanilla R platforms 
+	# (i.e. MRO and RRO), because last.warning is locked by default. To unlock the binding, use 
+	# unlockBinding("last.warning", baseenv()). This implementation is consistent with ?warning, w
+	# which says "If warn is zero (the default), a read-only variable last.warning is created."
+	# - Jthorpe Mar 9 '16 at 21:39
 	#######################################################
 	# BUT, THIS ADVICE NO LONGER WORKS IN VERSION 4.1
 	
@@ -1586,7 +1585,7 @@ bears_optim_run <- function(BioGeoBEARS_run_object = define_BioGeoBEARS_run(), s
 				minqa_TF = is.element("minqa", installed.packages()[,1])
 				if (minqa_TF == FALSE)
 					{
-					if (packageVersion("optimx") > 2017)
+					if (packageVersion("optimx") > "2017")
 						{
 						txt = "Warning in bears_optim_run(): optimx version 2018.7.10 requires package 'minqa' to do optimx ML optimization with the 'bobyqa' method (optimization with mix/max limits on parameters). However, optimx 2018.7.10 doesn't load 'minqa' automatically, so you may have to do:\n\ninstall.packages('minqa')\n\n...and re-run, to get rid of this warning, and/or the error where optimx returns NA for the parameter inferences after one step, and crashes the resulting uppass calculations."
 						cat("\n\n")
@@ -1890,7 +1889,7 @@ bears_optim_run <- function(BioGeoBEARS_run_object = define_BioGeoBEARS_run(), s
 					}
 				} else {
 				# optimx 2012 versus 2013
-				if (packageVersion("optimx") < 2013)
+				if (packageVersion("optimx") < "2013")
 					{
 					# optimx 2012
 					optim_result2 = optimx(par=params, fn=calc_loglike_for_optim, gr=NULL, hess=NULL, lower=lower, upper=upper, method=c("bobyqa"), itnmax=itnmax, hessian=NULL, control=control_list, BioGeoBEARS_run_object=BioGeoBEARS_run_object, phy=phy, tip_condlikes_of_data_on_each_state=tip_condlikes_of_data_on_each_state, print_optim=print_optim, areas_list=areas_list, states_list=states_list, force_sparse=force_sparse, cluster_already_open=cluster_already_open, return_what="loglike", calc_ancprobs=FALSE)
@@ -1907,7 +1906,7 @@ bears_optim_run <- function(BioGeoBEARS_run_object = define_BioGeoBEARS_run(), s
 					minqa_TF = is.element("minqa", installed.packages()[,1])
 					if (minqa_TF == FALSE)
 						{
-						if (packageVersion("optimx") > 2017)
+						if (packageVersion("optimx") > "2017")
 							{
 							txt = "Warning in bears_optim_run(): optimx version 2018.7.10 requires package 'minqa' to do optimx ML optimization with the 'bobyqa' method (optimization with mix/max limits on parameters). However, optimx 2018.7.10 doesn't load 'minqa' automatically, so you may have to do:\n\ninstall.packages('minqa')\n\n...and re-run, to get rid of this warning, and/or the error where optimx returns NA for the parameter inferences after one step, and crashes the resulting uppass calculations."
 							cat("\n\n")
@@ -2089,7 +2088,7 @@ bears_optim_run <- function(BioGeoBEARS_run_object = define_BioGeoBEARS_run(), s
 		if ( (BioGeoBEARS_run_object$use_optimx == TRUE) || (BioGeoBEARS_run_object$use_optimx == "optimx") )
 			{
 			# optimx 2013+
-			if (packageVersion("optimx") >= 2013)
+			if (packageVersion("optimx") >= "2013")
 				{
 				param_names = names(optim_result2)
 				param_1st_letter = substr(x=param_names, start=1, stop=1)
@@ -2099,7 +2098,7 @@ bears_optim_run <- function(BioGeoBEARS_run_object = define_BioGeoBEARS_run(), s
 				optim_result2[param_names] = BioGeoBEARS_model_object@params_table$est[BioGeoBEARS_model_object@params_table$type=="free"]
 				}
 			# optimx 2012
-			if (packageVersion("optimx") < 2013)
+			if (packageVersion("optimx") < "2013")
 				{
 				optim_result2$par[[1]] = BioGeoBEARS_model_object@params_table$est[BioGeoBEARS_model_object@params_table$type=="free"]
 				}


### PR DESCRIPTION
It appears the behavior for the line

```
  if(packageVersion("optimx") == 2017)
```

has changed such that the right hand side is coerced into a version string via (after some other calls) `make_numeric_version`, which only accepts character strings. The constant `2017` is interpreted as a double, which causes the function fail, which halts the script. The solution is simply to turn the numeric constants to string constants in this context.

Additionally, I replaced a unicode dash with an ascii dash, as it was causing problems when sourcing the script.