### PR TITLE
Bug fix:  count_ana_dispersal_event always returned 0 range contractions

### DIFF
--- a/R/summarize_BSM_tables_v1.R
+++ b/R/summarize_BSM_tables_v1.R
@@ -583,7 +583,7 @@ count_ana_dispersal_events <- function(ana_events_table, areanames, actual_names
 			} # END for (j in 1:length(areanames))
 
 		# Extinction/extirpation vector
-		TF = events_df2$extirpation_from == areanames[i]
+		TF = extirp_df2$extirpation_from == areanames[i]
 		if (sum(TF) > 0)
 			{
 			e_counts_list[,i] = sum(TF)

--- a/R/summarize_BSM_tables_v1.R
+++ b/R/summarize_BSM_tables_v1.R
@@ -1318,6 +1318,7 @@ count_ana_clado_events <- function(clado_events_tables, ana_events_tables, arean
 				{
 				e_counts_rectangle[i,] = as.matrix(e_counts_df)
 				e_totals_list[i] = sum(e_counts_df)
+				ana_totals_list[i] = ana_totals_list[i] + e_totals_list[i]
 				} else {
 				e_counts_rectangle[i,] = 0
 				e_totals_list[i] = 0


### PR DESCRIPTION
count_ana_dispersal_event always returned zero range contractions in Biogeographic stochastic mapping (BSM).
This was originally reported by Ollie White in 2020.

############ test if there is at least 1 extinction event (range contraction) reconstructed in any of the 50 stochastic mapping
BSMs_w_sourceAreas <- readRDS('BSMs_w_sourceAreas.RDS') # output from simulate_source_areas_ana_clado on example data (but it is true for any dataset)
any(count_ana_clado_events(BSMs_w_sourceAreas$clado_events_tables, BSMs_w_sourceAreas$ana_events_tables, c("K","O","M","H"), c("K","O","M","H"))$e_totals_list != 0)
[BSMs_w_sourceAreas.zip](https://github.com/user-attachments/files/21934038/BSMs_w_sourceAreas.zip)
